### PR TITLE
Fix failing test.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,7 @@ perl = 5.006
 App::Cmd = 0.3
 Getopt::Long::Descriptive = 0.091
 Moose = 0.86
+MooseX::ConfigFromFile = 0.08
 MooseX::Getopt = 0.18
 Test::use::ok = 0
 [Prereqs / ConfigureRequires]

--- a/lib/MooseX/App/Cmd/Command.pm
+++ b/lib/MooseX/App/Cmd/Command.pm
@@ -39,12 +39,8 @@ override _process_args => sub {
         }
         $opt_parser->getoptions( 'configfile=s' => \$configfile );
         if ( !defined $configfile ) {
-            my $cfmeta = $class->meta->find_attribute_by_name('configfile');
-            if ( $cfmeta->has_default ) {
-                my $default = $cfmeta->default;
-                $configfile
-                    = ref $default eq 'CODE' ? $default->($class) : $default;
-            }
+            $configfile = $class->_get_default_configfile()
+                if $class->can('_get_default_configfile');
         }
 
         if ( defined $configfile ) {

--- a/lib/MooseX/App/Cmd/Command.pm
+++ b/lib/MooseX/App/Cmd/Command.pm
@@ -43,7 +43,7 @@ override _process_args => sub {
             if ( $cfmeta->has_default ) {
                 my $default = $cfmeta->default;
                 $configfile
-                    = ref $default eq 'CODE' ? $default->() : $default;
+                    = ref $default eq 'CODE' ? $default->($class) : $default;
             }
         }
 

--- a/t/configfile.t
+++ b/t/configfile.t
@@ -52,6 +52,6 @@ my $cmd = Test::ConfigFromFile->new;
     like(
         $@,
         qr/ghosts go moo1 moo2 moo3/,
-        'default configfile() takes a sub()',
+        'default configfile read',
     );
 }

--- a/t/lib/Test/ConfigFromFile/Command/boo.pm
+++ b/t/lib/Test/ConfigFromFile/Command/boo.pm
@@ -19,8 +19,7 @@ has 'moo' => (
     documentation => "required option field",
 );
 
-has '+configfile' =>
-    ( default => sub {'t/lib/Test/ConfigFromFile/config.yaml'}, );
+sub _get_default_configfile { 't/lib/Test/ConfigFromFile/config.yaml' }
 
 sub execute {
     my ( $self, $opt, $arg ) = @_;


### PR DESCRIPTION
Fixes the one failing test introduced in MooseX::ConfigFromFile 0.08 and greater.  The test should work with older versions of MooseX::ConfigFromFile as well.
